### PR TITLE
ci: stop testing against NodeJS v14, v16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,8 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 14
-          - 16
           - 18
+          - 20
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node_version }}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       [
         "@pika/plugin-build-node",
         {
-          "minNodeVersion": "14"
+          "minNodeVersion": 18
         }
       ],
       [
@@ -102,6 +102,6 @@
     ]
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   }
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -42,7 +42,7 @@ async function main() {
       outdir: "pkg/dist-node",
       bundle: true,
       platform: "node",
-      target: "node14",
+      target: "node18",
       format: "cjs",
       ...sharedOptions,
     }),


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v14, v16